### PR TITLE
Add Jackson configuration for case insensitive enums.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,11 @@ spring:
         console:
             enabled: true
             path: /db-console
+            
+    jackson:
+        mapper:
+            accept-case-insensitive-enums: true
+    
     jpa:
         show-sql: true
         open-in-view: false


### PR DESCRIPTION
I found that the original code errored when using Enum values that were not uppercase. This adds configuration for Jackson to support mixed case Enums as found in the test examples.

Closes #6